### PR TITLE
Add secret control to load_secret.yaml

### DIFF
--- a/tasks/load_secret.yaml
+++ b/tasks/load_secret.yaml
@@ -8,8 +8,7 @@
   register: r_secret
 
 - name: Fail if no secret found
-  when: >-
-    r_secret.resources | length == 0
+  when: r_secret.resources | length == 0
   fail:
     msg: >-
       No secret {{ agnostics_placement_cloud }} found in namespace

--- a/tasks/load_secret.yaml
+++ b/tasks/load_secret.yaml
@@ -7,32 +7,17 @@
     kind: Secret
   register: r_secret
 
-- name: Try suffix '-no-repos' -- Read secret from agnostics_secrets_namespace
-  k8s_info:
-    namespace: "{{ agnostics_secrets_namespace }}"
-    name: "{{ agnostics_placement_cloud }}-no-repos"
-    api: v1
-    kind: Secret
-  register: r_secret_no_repo
-  when: r_secret.resources | length == 0
-
 - name: Fail if no secret found
   when: >-
     r_secret.resources | length == 0
-    and
-    r_secret_no_repo.resources | length == 0
   fail:
     msg: >-
       No secret {{ agnostics_placement_cloud }} found in namespace
       {{ agnostics_secrets_namespace }}
-
-- name: Use defined secret
-  set_fact:
-    n_secret: "{% if r_secret.resources|length == 0 %}{{ r_secret_no_repo }}{% else %}{{ r_secret }}{% endif %}"
 
 - name: Convert values from base64 and Inject secrets into dynamic_job_vars
   set_fact:
     dynamic_job_vars: >-
       {{ vars.dynamic_job_vars
       | default({})
-      | combine(n_secret.resources[0].data | convert_secret, recursive=True) }}
+      | combine(r_secret.resources[0].data | convert_secret, recursive=True) }}

--- a/tasks/load_secret.yaml
+++ b/tasks/load_secret.yaml
@@ -13,19 +13,26 @@
     name: "{{ agnostics_placement_cloud }}-no-repos"
     api: v1
     kind: Secret
-  register: r_secret
+  register: r_secret_no_repo
   when: r_secret.resources | length == 0
 
 - name: Fail if no secret found
-  when: r_secret.resources | length == 0
+  when: >-
+    r_secret.resources | length == 0
+    and
+    r_secret_no_repo.resources | length == 0
   fail:
     msg: >-
       No secret {{ agnostics_placement_cloud }} found in namespace
       {{ agnostics_secrets_namespace }}
+
+- name: Use defined secret
+  set_fact:
+    n_secret: "{% if r_secret.resources|length == 0 %}{{ r_secret_no_repo }}{% else %}{{ r_secret }}{% endif %}"
 
 - name: Convert values from base64 and Inject secrets into dynamic_job_vars
   set_fact:
     dynamic_job_vars: >-
       {{ vars.dynamic_job_vars
       | default({})
-      | combine(r_secret.resources[0].data | convert_secret, recursive=True) }}
+      | combine(n_secret.resources[0].data | convert_secret, recursive=True) }}


### PR DESCRIPTION
Reason: 

When *Try suffix '-no-repos'* runs and it's skipped ***r_secret*** is overwritten:

```
    "r_secret": {
        "changed": false,
        "skip_reason": "Conditional result was False",
        "skipped": true
    }
```

Purposed change:

Use two different variables, evaluate which is the correct one and assign it for use.

Purposed change after GC review:

Remove the whole no-repos task. Fixes the issue and play is more clean.